### PR TITLE
lint: set eof to auto for prettier to fix newline issue

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,4 +4,5 @@ module.exports = {
   bracketSpacing: false,
   singleQuote: true,
   trailingComma: 'all',
+  endOfLine: 'auto',
 };


### PR DESCRIPTION
I'm using vscode on mac, seeing this error "Delete `␍`" in a lot of files, set eof to auto to fix it.

Ref: [Why do I keep getting "[eslint] Delete `CR` [prettier/prettier]"?](https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-eslint-delete-cr-prettier-prettier)